### PR TITLE
Natigetor導入から画面遷移まで

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,46 +1,6 @@
-import React, { useState, useEffect } from "react";
-import { StyleSheet, FlatList, SafeAreaView, Platform } from "react-native";
-import ListItem from "./components/ListItem";
-import Constants from "expo-constants";
-import axios from "axios";
-
-const URL = `http://newsapi.org/v2/top-headlines?country=jp&apiKey=${Constants.manifest.extra.newsApiKey}`;
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: "#fff",
-    paddingTop: Platform.OS === "android" ? 25 : 0,
-  },
-});
+import React from "react";
+import AppNavigator from "./navigation/AppNatigator";
 
 export default function App() {
-  const [articles, setArticles] = useState([]);
-  useEffect(() => {
-    fetchArticles();
-  }, []);
-
-  const fetchArticles = async () => {
-    try {
-      const response = await axios.get(URL);
-      setArticles(response.data.articles);
-    } catch (error) {
-      console.error(error);
-    }
-  };
-  return (
-    <SafeAreaView style={styles.container}>
-      <FlatList
-        data={articles}
-        renderItem={({ item }) => (
-          <ListItem
-            imageUrl={item.urlToImage}
-            title={item.title}
-            author={item.author}
-          />
-        )}
-        keyExtractor={(item, index) => index.toString()}
-      />
-    </SafeAreaView>
-  );
+  return <AppNavigator />;
 }

--- a/App.js
+++ b/App.js
@@ -1,6 +1,12 @@
 import React from "react";
 import AppNavigator from "./navigation/AppNatigator";
+import { Provider } from "react-redux";
+import store from "./store/index";
 
 export default function App() {
-  return <AppNavigator />;
+  return (
+    <Provider store={store}>
+      <AppNavigator />
+    </Provider>
+  );
 }

--- a/README.md
+++ b/README.md
@@ -91,13 +91,58 @@ react には`function component`と`class component`の 2 種類の記載方法�
   State, ライフサイクル(ComponentDidMount など)を使えると言われていたが、Hooks の導入からその差はなくなっている。
   記述をシンプルにかける、動作が少し早い？を言われている。
 
-#### REACT NATIVE の API
+#### Expo(ReactNative) の API
+
+- expo
+  > https://docs.expo.io/
+- react native
+
+  > https://reactnative.dev/docs/getting-started
 
 - FlatList
   スクロール可能のリストを読み込む
 
 - SafeAreaView
   アプリに余白エリアを入れた表示をする
+
+- TouchavleOpacity
+  タッチイベント
+
+- webView
+  webUrl から サイトを表示
+
+#### React Navigation
+
+> https://reactnavigation.org/
+
+- インストール
+
+```
+$ npm install @react-navigation/native
+```
+
+- Expo managed project のため以下をインストール
+
+```
+$ expo install react-native-gesture-handler react-native-reanimated react-native-screens react-native-safe-area-context @react-native-community/masked-view
+```
+
+- 今後使うため stackNavigator をインストール
+
+```
+$ npm install @react-navigation/stack
+```
+
+- Hello React Navigation
+
+Navigator からの表示まで
+
+- Moving between screens
+
+画面の遷移の書き方
+
+- Passing parameters to routes
+  画面間のパラメータの受け渡し
 
 #### Hook の導入(function コンポーネント)
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ Navigator からの表示まで
 - Passing parameters to routes
   画面間のパラメータの受け渡し
 
+- createBottomTabNavigator
+  下に TAB ナビゲーションを表示
+
 #### Hook の導入(function コンポーネント)
 
 フック (hook) は React 16.8 で追加された新機能です。

--- a/components/ListItem.js
+++ b/components/ListItem.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { StyleSheet, Text, View, Image } from "react-native";
+import { StyleSheet, Text, View, Image, TouchableOpacity } from "react-native";
 
 const styles = StyleSheet.create({
   itemContainer: {
@@ -27,9 +27,9 @@ const styles = StyleSheet.create({
   },
 });
 
-const ListItem = ({ imageUrl, title, author }) => {
+const ListItem = ({ imageUrl, title, author, onPress }) => {
   return (
-    <View style={styles.itemContainer}>
+    <TouchableOpacity style={styles.itemContainer} onPress={onPress}>
       <View style={styles.leftContainer}>
         {!!imageUrl && (
           <Image
@@ -46,7 +46,7 @@ const ListItem = ({ imageUrl, title, author }) => {
         </Text>
         <Text style={styles.sabText}>{author}</Text>
       </View>
-    </View>
+    </TouchableOpacity>
   );
 };
 

--- a/navigation/AppNatigator.js
+++ b/navigation/AppNatigator.js
@@ -1,26 +1,64 @@
 import React from "react";
 import { NavigationContainer } from "@react-navigation/native";
 import { createStackNavigator } from "@react-navigation/stack";
+import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
+import { FontAwesome } from "@expo/vector-icons";
 import HomeScreen from "../screens/HomeScreen";
 import ArticleScreen from "../screens/ArticleScreen";
+import ClipScreen from "../screens/ClipScreen";
 
 const Stack = createStackNavigator();
+const Tab = createBottomTabNavigator();
+
+const HomeStack = () => {
+  return (
+    <Stack.Navigator>
+      <Stack.Screen
+        name="Home"
+        component={HomeScreen}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name="Article"
+        component={ArticleScreen}
+        ptions={{ headerShown: false }}
+      />
+    </Stack.Navigator>
+  );
+};
+
+const ClipStack = () => {
+  return (
+    <Stack.Navigator>
+      <Stack.Screen
+        name="Clip"
+        component={ClipScreen}
+        options={{ headerShown: false }}
+      />
+    </Stack.Navigator>
+  );
+};
+
+const screenOption = ({ route }) => ({
+  tabBarIcon: ({ color, size }) => {
+    let iconName;
+
+    if (route.name === "Home") {
+      iconName = "home";
+    } else if (route.name === "Clip") {
+      iconName = "bookmark";
+    }
+    return <FontAwesome name={iconName} size={size} color={color} />;
+  },
+});
 
 export default AppNavigator = () => {
   return (
     <NavigationContainer>
-      <Stack.Navigator>
-        <Stack.Screen
-          name="Home"
-          component={HomeScreen}
-          options={{ headerShown: false }}
-        />
-        <Stack.Screen
-          name="Article"
-          component={ArticleScreen}
-          ptions={{ headerShown: false }}
-        />
-      </Stack.Navigator>
+      <Tab.Navigator screenOptions={screenOption}>
+        <Tab.Screen name="Home" component={HomeStack} />
+        <Tab.Screen name="Clip" component={ClipStack} />
+      </Tab.Navigator>
     </NavigationContainer>
   );
 };

--- a/navigation/AppNatigator.js
+++ b/navigation/AppNatigator.js
@@ -1,0 +1,26 @@
+import React from "react";
+import { NavigationContainer } from "@react-navigation/native";
+import { createStackNavigator } from "@react-navigation/stack";
+import HomeScreen from "../screens/HomeScreen";
+import ArticleScreen from "../screens/ArticleScreen";
+
+const Stack = createStackNavigator();
+
+export default AppNavigator = () => {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen
+          name="Home"
+          component={HomeScreen}
+          options={{ headerShown: false }}
+        />
+        <Stack.Screen
+          name="Article"
+          component={ArticleScreen}
+          ptions={{ headerShown: false }}
+        />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1055,6 +1055,14 @@
         "minimist": "^1.2.0"
       }
     },
+    "@egjs/hammerjs": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
+      "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
+      "requires": {
+        "@types/hammerjs": "^2.0.36"
+      }
+    },
     "@expo/configure-splash-screen": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/@expo/configure-splash-screen/-/configure-splash-screen-0.1.12.tgz",
@@ -1563,10 +1571,66 @@
       "resolved": "https://registry.npmjs.org/@react-native-community/cli-types/-/cli-types-4.10.1.tgz",
       "integrity": "sha512-ael2f1onoPF3vF7YqHGWy7NnafzGu+yp88BbFbP0ydoCP2xGSUzmZVw0zakPTC040Id+JQ9WeFczujMkDy6jYQ=="
     },
+    "@react-native-community/masked-view": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@react-native-community/masked-view/-/masked-view-0.1.10.tgz",
+      "integrity": "sha512-rk4sWFsmtOw8oyx8SD3KSvawwaK7gRBSEIy2TAwURyGt+3TizssXP1r8nx3zY+R7v2vYYHXZ+k2/GULAT/bcaQ=="
+    },
+    "@react-navigation/core": {
+      "version": "5.12.2",
+      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-5.12.2.tgz",
+      "integrity": "sha512-ybsnttbYpyCVN7jGHEIfOKg6Bdyr0seXvxUMtSJNt3mI33KWMRJrqyYU2ILoxAaDdRcBItvBlOYWxMRrBJyZkQ==",
+      "requires": {
+        "@react-navigation/routers": "^5.4.10",
+        "escape-string-regexp": "^4.0.0",
+        "nanoid": "^3.1.9",
+        "query-string": "^6.13.1",
+        "react-is": "^16.13.0",
+        "use-subscription": "^1.4.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        }
+      }
+    },
+    "@react-navigation/native": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-5.7.2.tgz",
+      "integrity": "sha512-pGaiCg5G0aUol1+J50xx6ioq+wlXGOqxdlZaHgVwlYbYuuHLC1ForsH1wIzQdUHBEfHiw5/VDxFwRX5p1dHUCg==",
+      "requires": {
+        "@react-navigation/core": "^5.12.2",
+        "nanoid": "^3.1.9"
+      }
+    },
+    "@react-navigation/routers": {
+      "version": "5.4.10",
+      "resolved": "https://registry.npmjs.org/@react-navigation/routers/-/routers-5.4.10.tgz",
+      "integrity": "sha512-uOcz3HugGBjCSPz4EG3LLjk8cBrBm0cK04c+OxPG/0xC9gfOYKrjlGnxGtZy+bXdITrn7179U0wx2vVEf2sclw==",
+      "requires": {
+        "nanoid": "^3.1.9"
+      }
+    },
+    "@react-navigation/stack": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@react-navigation/stack/-/stack-5.8.0.tgz",
+      "integrity": "sha512-gp4Rcst86OEFAwZG/AM904ueQ4wQDCpY8XP63ToqJMgU0mCFSABVZCFwo0GuhpCs8KAtH/tAf6X2aQFDpmlaNg==",
+      "requires": {
+        "color": "^3.1.2",
+        "react-native-iphone-x-helper": "^1.2.1"
+      }
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+    },
+    "@types/hammerjs": {
+      "version": "2.0.36",
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.36.tgz",
+      "integrity": "sha512-7TUK/k2/QGpEAv/BCwSHlYu3NXZhQ9ZwBYpzr9tjlPIL2C5BeGhH3DmVavRx3ZNyELX5TLC91JTz/cen6AAtIQ=="
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
@@ -2308,6 +2372,15 @@
       "requires": {
         "map-visit": "^1.0.0",
         "object-visit": "^1.0.0"
+      }
+    },
+    "color": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
+      "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
+      "requires": {
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2"
       }
     },
     "color-convert": {
@@ -3552,6 +3625,11 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/hermes-engine/-/hermes-engine-0.0.0.tgz",
       "integrity": "sha512-q5DP4aUe6LnfMaLsxFP1cCY5qA0Ca5Qm2JQ/OgKi3sTfPpXth79AQ7vViXh/RRML53EpokDewMLJmI31RioBAA=="
+    },
+    "hoist-non-react-statics": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
     },
     "http-errors": {
       "version": "1.7.3",
@@ -5060,6 +5138,11 @@
       "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
       "optional": true
     },
+    "nanoid": {
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
+      "integrity": "sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A=="
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -5592,6 +5675,16 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
       "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
     },
+    "query-string": {
+      "version": "6.13.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.1.tgz",
+      "integrity": "sha512-RfoButmcK+yCta1+FuU8REvisx1oEzhMKwhLUNcepQTPGcNMp1sIqjnfCtfnvGSQZQEhaBHvccujtWoUV3TTbA==",
+      "requires": {
+        "decode-uri-component": "^0.2.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      }
+    },
     "querystringify": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
@@ -5915,10 +6008,39 @@
         "use-subscription": "^1.0.0"
       }
     },
+    "react-native-gesture-handler": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-1.6.1.tgz",
+      "integrity": "sha512-gQgIKhDiYf754yzhhliagLuLupvGb6ZyBdzYzr7aus3Fyi87TLOw63ers+r4kGw0h26oAWTAdHd34JnF4NeL6Q==",
+      "requires": {
+        "@egjs/hammerjs": "^2.0.17",
+        "hoist-non-react-statics": "^2.3.1",
+        "invariant": "^2.2.4",
+        "prop-types": "^15.7.2"
+      }
+    },
+    "react-native-iphone-x-helper": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.2.1.tgz",
+      "integrity": "sha512-/VbpIEp8tSNNHIvstuA3Swx610whci1Zpc9mqNkqn14DkMbw+ORviln2u0XyHG1kPvvwTNGZY6QpeFwxYaSdbQ=="
+    },
+    "react-native-reanimated": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-1.9.0.tgz",
+      "integrity": "sha512-Aj+spgIHRiVv7ezGADxnSH1EoKrQRD2+XaSiGY0MiB/pvRNNrZPSJ+3NVpvLwWf9lZMOP7dwqqyJIzoZgBDt8w==",
+      "requires": {
+        "fbjs": "^1.0.0"
+      }
+    },
     "react-native-safe-area-context": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-3.0.7.tgz",
       "integrity": "sha512-dqhRTlIFe5+P1yxitj0C9XVUxLqOmjomeqzUSSY8sNOWVjtIhEY/fl4ZKYpAVnktd8dt3zl13XmJTmRmy3d0uA=="
+    },
+    "react-native-screens": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-2.9.0.tgz",
+      "integrity": "sha512-5MaiUD6HA3nzY3JbVI8l3V7pKedtxQF3d8qktTVI0WmWXTI4QzqOU8r8fPVvfKo3MhOXwhWBjr+kQ7DZaIQQeg=="
     },
     "react-native-web": {
       "version": "0.11.7",
@@ -5935,6 +6057,22 @@
         "normalize-css-color": "^1.0.2",
         "prop-types": "^15.6.0",
         "react-timer-mixin": "^0.13.4"
+      }
+    },
+    "react-native-webview": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-9.4.0.tgz",
+      "integrity": "sha512-BBOFUuza0p04+7fNi7TJmB0arpDJzGxHYwTCgI4vj5n/fl7u4jbm7ETp88mf7lo9lP6C6HGLo38KnEy1aXCQkg==",
+      "requires": {
+        "escape-string-regexp": "2.0.0",
+        "invariant": "2.2.4"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
+        }
       }
     },
     "react-refresh": {
@@ -6527,6 +6665,11 @@
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
     },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -6581,6 +6724,11 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
       "integrity": "sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ="
+    },
+    "strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string-width": {
       "version": "2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1576,6 +1576,15 @@
       "resolved": "https://registry.npmjs.org/@react-native-community/masked-view/-/masked-view-0.1.10.tgz",
       "integrity": "sha512-rk4sWFsmtOw8oyx8SD3KSvawwaK7gRBSEIy2TAwURyGt+3TizssXP1r8nx3zY+R7v2vYYHXZ+k2/GULAT/bcaQ=="
     },
+    "@react-navigation/bottom-tabs": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/@react-navigation/bottom-tabs/-/bottom-tabs-5.7.3.tgz",
+      "integrity": "sha512-sLlnxhrAdRzEvzI9jJS46DMveTu/Ij5f0cE+5F6AGUT4M5Ge4HPtTU3e4HRvXioVwj+Gn/nzRA928BtTin10gQ==",
+      "requires": {
+        "color": "^3.1.2",
+        "react-native-iphone-x-helper": "^1.2.1"
+      }
+    },
     "@react-navigation/core": {
       "version": "5.12.2",
       "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-5.12.2.tgz",
@@ -6075,6 +6084,28 @@
         }
       }
     },
+    "react-redux": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.1.tgz",
+      "integrity": "sha512-T+VfD/bvgGTUA74iW9d2i5THrDQWbweXP0AVNI8tNd1Rk5ch1rnMiJkDD67ejw7YBKM4+REvcvqRuWJb7BLuEg==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "hoist-non-react-statics": "^3.3.0",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.9.0"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+          "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+          "requires": {
+            "react-is": "^16.7.0"
+          }
+        }
+      }
+    },
     "react-refresh": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.4.3.tgz",
@@ -6105,6 +6136,27 @@
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         }
       }
+    },
+    "redux": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.5.tgz",
+      "integrity": "sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "symbol-observable": "^1.2.0"
+      },
+      "dependencies": {
+        "symbol-observable": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+          "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+        }
+      }
+    },
+    "redux-devtools-extension": {
+      "version": "2.13.8",
+      "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.8.tgz",
+      "integrity": "sha512-8qlpooP2QqPtZHQZRhx3x3OP5skEV1py/zUdMY28WNAocbafxdG2tRD1MWE7sp8obGMNYuLWanhhQ7EQvT1FBg=="
     },
     "regenerate": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@react-native-community/masked-view": "0.1.10",
+    "@react-navigation/bottom-tabs": "^5.7.3",
     "@react-navigation/native": "^5.7.2",
     "@react-navigation/stack": "^5.8.0",
     "axios": "^0.19.2",
@@ -23,7 +24,10 @@
     "react-native-safe-area-context": "~3.0.7",
     "react-native-screens": "~2.9.0",
     "react-native-web": "~0.11.7",
-    "react-native-webview": "9.4.0"
+    "react-native-webview": "9.4.0",
+    "react-redux": "^7.2.1",
+    "redux": "^4.0.5",
+    "redux-devtools-extension": "^2.13.8"
   },
   "devDependencies": {
     "@babel/core": "^7.8.6",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "eject": "expo eject"
   },
   "dependencies": {
+    "@react-native-community/masked-view": "0.1.10",
+    "@react-navigation/native": "^5.7.2",
+    "@react-navigation/stack": "^5.8.0",
     "axios": "^0.19.2",
     "expo": "~38.0.8",
     "expo-constants": "~9.1.1",
@@ -15,7 +18,12 @@
     "react": "~16.11.0",
     "react-dom": "~16.11.0",
     "react-native": "https://github.com/expo/react-native/archive/sdk-38.0.2.tar.gz",
-    "react-native-web": "~0.11.7"
+    "react-native-gesture-handler": "~1.6.0",
+    "react-native-reanimated": "~1.9.0",
+    "react-native-safe-area-context": "~3.0.7",
+    "react-native-screens": "~2.9.0",
+    "react-native-web": "~0.11.7",
+    "react-native-webview": "9.4.0"
   },
   "devDependencies": {
     "@babel/core": "^7.8.6",

--- a/screens/ArticleScreen.js
+++ b/screens/ArticleScreen.js
@@ -1,0 +1,20 @@
+import React from "react";
+import { StyleSheet, SafeAreaView } from "react-native";
+import { WebView } from "react-native-webview";
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#fff",
+    paddingTop: Platform.OS === "android" ? 25 : 0,
+  },
+});
+
+export default ArticleScreen = ({ route }) => {
+  const { article } = route.params;
+  return (
+    <SafeAreaView style={styles.container}>
+      <WebView source={{ uri: article.url }} style={{ marginTop: 20 }} />
+    </SafeAreaView>
+  );
+};

--- a/screens/ArticleScreen.js
+++ b/screens/ArticleScreen.js
@@ -1,6 +1,8 @@
 import React from "react";
-import { StyleSheet, SafeAreaView } from "react-native";
+import { StyleSheet, SafeAreaView, TouchableOpacity, Text } from "react-native";
 import { WebView } from "react-native-webview";
+import { useDispatch } from "react-redux";
+import { addClip, deleteClip } from "../store/actions/user";
 
 const styles = StyleSheet.create({
   container: {
@@ -12,8 +14,24 @@ const styles = StyleSheet.create({
 
 export default ArticleScreen = ({ route }) => {
   const { article } = route.params;
+
+  const dispatch = useDispatch();
   return (
     <SafeAreaView style={styles.container}>
+      <TouchableOpacity
+        onPress={() => {
+          dispatch(addClip({ clip: article }));
+        }}
+      >
+        <Text style={{ margin: 10, fontSize: 10 }}>ADD CLIP</Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        onPress={() => {
+          dispatch(deleteClip({ clip: article }));
+        }}
+      >
+        <Text style={{ margin: 10, fontSize: 10 }}>DELETE CLIP</Text>
+      </TouchableOpacity>
       <WebView source={{ uri: article.url }} style={{ marginTop: 20 }} />
     </SafeAreaView>
   );

--- a/screens/ClipScreen.js
+++ b/screens/ClipScreen.js
@@ -1,0 +1,18 @@
+import React from "react";
+import { StyleSheet, SafeAreaView, Platform, Text } from "react-native";
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#fff",
+    paddingTop: Platform.OS === "android" ? 25 : 0,
+  },
+});
+
+export default ClipScreen = () => {
+  return (
+    <SafeAreaView style={styles.container}>
+      <Text>Clip Screen</Text>
+    </SafeAreaView>
+  );
+};

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -1,0 +1,48 @@
+import React, { useState, useEffect } from "react";
+import { StyleSheet, FlatList, SafeAreaView, Platform } from "react-native";
+import ListItem from "../components/ListItem";
+import Constants from "expo-constants";
+import axios from "axios";
+
+const URL = `http://newsapi.org/v2/top-headlines?country=jp&apiKey=${Constants.manifest.extra.newsApiKey}`;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#fff",
+    paddingTop: Platform.OS === "android" ? 25 : 0,
+  },
+});
+
+export default HomeScreen = (props) => {
+  const { navigation } = props;
+  const [articles, setArticles] = useState([]);
+  useEffect(() => {
+    fetchArticles();
+  }, []);
+
+  const fetchArticles = async () => {
+    try {
+      const response = await axios.get(URL);
+      setArticles(response.data.articles);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+  return (
+    <SafeAreaView style={styles.container}>
+      <FlatList
+        data={articles}
+        renderItem={({ item }) => (
+          <ListItem
+            imageUrl={item.urlToImage}
+            title={item.title}
+            author={item.author}
+            onPress={() => navigation.navigate("Article", { article: item })}
+          />
+        )}
+        keyExtractor={(item, index) => index.toString()}
+      />
+    </SafeAreaView>
+  );
+};

--- a/store/actions/actionType.js
+++ b/store/actions/actionType.js
@@ -1,0 +1,2 @@
+export const ADD_CLIP = "ADD_CLIP";
+export const DELETE_CLIP = "DELETE_CLIP";

--- a/store/actions/user.js
+++ b/store/actions/user.js
@@ -1,0 +1,15 @@
+import { ADD_CLIP, DELETE_CLIP } from "./actionType";
+
+export const addClip = ({ clip }) => {
+  return {
+    type: ADD_CLIP,
+    clip,
+  };
+};
+
+export const deleteClip = ({ clip }) => {
+  return {
+    type: DELETE_CLIP,
+    clip,
+  };
+};

--- a/store/index.js
+++ b/store/index.js
@@ -1,0 +1,11 @@
+import { combineReducers, createStore, applyMiddleware } from "redux";
+import userReducer from "./reducers/user";
+import { composeWithDevTools } from "redux-devtools-extension";
+
+const rootReducer = combineReducers({
+  user: userReducer,
+});
+
+const store = createStore(rootReducer, composeWithDevTools());
+
+export default store;

--- a/store/reducers/user.js
+++ b/store/reducers/user.js
@@ -1,0 +1,24 @@
+import { ADD_CLIP, DELETE_CLIP } from "../actions/actionType";
+
+const initialState = {
+  clips: [],
+};
+
+const reducer = (state = initialState, action) => {
+  switch (action.type) {
+    case ADD_CLIP:
+      return {
+        ...state,
+        clips: [...state.clips, action.clip],
+      };
+    case DELETE_CLIP:
+      return {
+        ...state,
+        clips: state.clips.filter((clip) => clip.url !== action.clip.url),
+      };
+    default:
+      return state;
+  }
+};
+
+export default reducer;


### PR DESCRIPTION
# Natigetor導入から画面遷移まで
画面遷移が可能となった。
webViewでarticleScreenからurlを呼び出して元の記事を表示している

### expo & React Native
以下を使うことでタッチイベント時にwebViewを表示することが可能となった
- TouchavleOpacity
- webView

### React Navigation
Screenごとに切り分けることでonPress時に、関数navigation.navigate([screen名])で別画面コンポーネントを呼び出すことができた。第二引数は画面間でパラメータを渡すことが可能
